### PR TITLE
Limit issue description length

### DIFF
--- a/src/app/shared/comment-editor/comment-editor.component.html
+++ b/src/app/shared/comment-editor/comment-editor.component.html
@@ -24,10 +24,17 @@
             cdkAutosizeMaxRows="20"
             class="text-input-area"
             placeholder="{{ this.placeholderText }}"
+            maxlength="{{ this.maxLength }}"
           ></textarea>
           <mat-error *ngIf="commentField.errors && commentField.errors['required'] && commentField.touched">
             Description required.
           </mat-error>
+          <mat-error *ngIf="commentField.errors && commentField.errors['maxLength']">
+            Description cannot exceed {{ maxLength }} characters.
+          </mat-error>
+          <mat-hint *ngIf="commentField.value?.length >= maxLength - 50">
+            {{ maxLength - commentField.value?.length }} character(s) remaining.
+          </mat-hint>
 
           <div class="drag-and-drop">
             <span *ngIf="!isInErrorState"> Attach files by dragging & dropping or select them by clicking here. </span>

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -49,7 +49,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
-  maxLength = 40000;
+  @Input() maxLength = 40000;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -50,7 +50,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
-  @Input() maxLength = ISSUE_BODY_SIZE_LIMIT;
+  maxLength = ISSUE_BODY_SIZE_LIMIT;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -1,6 +1,6 @@
 import { HttpErrorResponse } from '@angular/common/http';
 import { Component, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
-import { AbstractControl, FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup, Validators } from '@angular/forms';
 import * as DOMPurify from 'dompurify';
 import { ErrorHandlingService } from '../../core/services/error-handling.service';
 import { LoggingService } from '../../core/services/logging.service';
@@ -49,6 +49,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
+  maxLength = 40000;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';
@@ -64,6 +65,7 @@ export class CommentEditorComponent implements OnInit {
     }
 
     this.initialSubmitButtonText = this.submitButtonText;
+    this.commentField.setValidators([Validators.maxLength(this.maxLength)]);
   }
 
   onDragEnter(event) {

--- a/src/app/shared/comment-editor/comment-editor.component.ts
+++ b/src/app/shared/comment-editor/comment-editor.component.ts
@@ -14,6 +14,7 @@ const TIME_BETWEEN_UPLOADS_MS = 250;
 
 const MAX_UPLOAD_SIZE = (SHOWN_MAX_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 11MB to allow 10.x MB
 const MAX_VIDEO_UPLOAD_SIZE = (SHOWN_MAX_VIDEO_UPLOAD_SIZE_MB + 1) * BYTES_PER_MB; // 6MB to allow 5.x MB
+const ISSUE_BODY_SIZE_LIMIT = 40000;
 
 @Component({
   selector: 'app-comment-editor',
@@ -49,7 +50,7 @@ export class CommentEditorComponent implements OnInit {
 
   dragActiveCounter = 0;
   uploadErrorMessage: string;
-  @Input() maxLength = 40000;
+  @Input() maxLength = ISSUE_BODY_SIZE_LIMIT;
 
   formatFileUploadingButtonText(currentButtonText: string) {
     return currentButtonText + ' (Waiting for File Upload to finish...)';


### PR DESCRIPTION
### Summary:
Addresses #906:
> GitHub APIs (used by the CATcher issue transfer scripts) has a limit of 65536 chars for the issue body. Perhaps CATcher can limit the body size to 40,000 chars? The lower internal limit is because we might have to add additional content to the issue body in later stages of the PE.

### Changes Made:
* Add a `maxLength` property to the comment-editor component with a default value of 40000
* Assign the value of the above property to the `maxLength` attribute of textarea in comment-editor's template
* Add a hint label to display the number of remaining characters when the user enters more than 39949 characters

The comment-editor is used in many components, including the new-issue component where the bug was reported in #901. Applying the limit in the comment-editor ensures consistency across components that require multi-line user input. At the same time, components that use the comment-editor can modify the limit by assigning a different value to the `maxLength` property of comment-editor.

### Demo:

https://user-images.githubusercontent.com/76725246/174722034-0340fefa-c5c4-4196-a790-5d6fbf11b06b.mp4
